### PR TITLE
Update Inception/classify_image.py

### DIFF
--- a/Chapter04/Inception/classify_image.py
+++ b/Chapter04/Inception/classify_image.py
@@ -43,7 +43,7 @@ import tarfile
 
 import numpy as np
 from six.moves import urllib
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 FLAGS = None
 


### PR DESCRIPTION
The current Inception-v3/classify-image.py is developed in TensorFlow 1.6 that is outdated. Here is a modified version for TensorFlow 2.0

Change 
import tensorflow as tf
to
import tensorflow.compat.v1 as tf